### PR TITLE
refactor(SnoozePanel): replace react-loadable with React.lazy and Suspense

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react-day-picker": "^9.8.0",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
-    "react-loadable": "^5.5.0",
     "react-router-dom": "^7.7.0",
     "sanitize-html": "^2.17.0",
     "styled-components": "^6.1.19"

--- a/src/components/SnoozePanel/SnoozePanel.jsx
+++ b/src/components/SnoozePanel/SnoozePanel.jsx
@@ -2,7 +2,7 @@
 import type { SnoozeOption } from './calcSnoozeOptions';
 import type { Props as SnoozeButtonProps } from './SnoozeButton';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, Suspense, lazy } from 'react';
 import styled from 'styled-components';
 // import bugsnag from '../../bugsnag';
 import calcSnoozeOptions, {
@@ -31,19 +31,10 @@ import {
   getActiveTab,
 } from '../../core/utils';
 // import { getUpgradeUrl } from '../../paths';
-import Loadable from 'react-loadable';
-
-
-const AsyncComp = props =>
-  Loadable({ ...props, loading: () => null });
 
 // code splitting these big components
-const AsyncPeriodSelector = AsyncComp({
-  loader: () => import('./PeriodSelector'),
-});
-const AsyncDateSelector = AsyncComp({
-  loader: () => import('./DateSelector'),
-});
+const AsyncPeriodSelector = lazy(() => import('./PeriodSelector'));
+const AsyncDateSelector = lazy(() => import('./DateSelector'));
 
 type Props = {
   hideFooter: boolean,
@@ -238,22 +229,26 @@ export function SnoozePanel(props: Props): React.Node {
         betaBadge={IS_BETA}
       />
       {selectedSnoozeOptionId === SNOOZE_TYPE_REPEATED && (
-        <AsyncPeriodSelector
-          onPeriodSelected={onSnoozePeriodSelected}
-          visible={
-            selectorDialogOpen &&
-            selectedSnoozeOptionId === SNOOZE_TYPE_REPEATED
-          }
-        />
+        <Suspense fallback={null}>
+          <AsyncPeriodSelector
+            onPeriodSelected={onSnoozePeriodSelected}
+            visible={
+              selectorDialogOpen &&
+              selectedSnoozeOptionId === SNOOZE_TYPE_REPEATED
+            }
+          />
+        </Suspense>
       )}
       {selectedSnoozeOptionId === SNOOZE_TYPE_SPECIFIC_DATE && (
-        <AsyncDateSelector
-          onDateSelected={onSnoozeSpecificDateSelected}
-          visible={
-            selectorDialogOpen &&
-            selectedSnoozeOptionId === SNOOZE_TYPE_SPECIFIC_DATE
-          }
-        />
+        <Suspense fallback={null}>
+          <AsyncDateSelector
+            onDateSelected={onSnoozeSpecificDateSelected}
+            visible={
+              selectorDialogOpen &&
+              selectedSnoozeOptionId === SNOOZE_TYPE_SPECIFIC_DATE
+            }
+          />
+        </Suspense>
       )}
       <UpgradeDialog
         onDismiss={() =>


### PR DESCRIPTION
## Summary
- Replace deprecated `react-loadable` library with React 18's native `React.lazy` and `Suspense`
- Remove `react-loadable` dependency from package.json

## Test plan
- [ ] Run `npm run dev` and click snooze buttons
- [ ] Verify PeriodSelector and DateSelector lazy load correctly
- [ ] Run `npm run build` to ensure production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)