### PR TITLE
feat: Allow opening sleeping tabs without deleting them

### DIFF
--- a/src/components/OptionsPage/SleepingTabsPage.jsx
+++ b/src/components/OptionsPage/SleepingTabsPage.jsx
@@ -103,7 +103,7 @@ const SleepingTabsPage = (props: Props): React.Node => {
     );
 
     // delay wakeup for click ripple animation to finish
-    setTimeout(() => wakeupTabs([tab], makeTabActive), 300);
+    setTimeout(() => wakeupTabs({ tabs: [tab], makeActive: makeTabActive, deleteAfterWakeup: false }), 300);
   }
 
   const renderTabGroup = (tabGroup: TabGroup, index: number) =>{

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -102,28 +102,35 @@ export async function deleteSnoozedTabs(
 }
 
 /*
-    Create tabs, notify user, and delete from storage
+    Create tabs, notify user, and optionally delete from storage
 */
-export async function wakeupTabs(
-  tabsToWakeUp: Array<SnoozedTab>,
-  makeActive: boolean
-): Promise<Array<ChromeTab>> {
-  console.log(`Waking up ${tabsToWakeUp.length} tabs`);
+export async function wakeupTabs({
+  tabs,
+  makeActive = false,
+  deleteAfterWakeup = true,
+}: {
+  tabs: Array<SnoozedTab>,
+  makeActive?: boolean,
+  deleteAfterWakeup?: boolean,
+}): Promise<Array<ChromeTab>> {
+  console.log(`Waking up ${tabs.length} tabs`);
 
-  // delete waking tabs from storage
-  await deleteSnoozedTabs(tabsToWakeUp);
+  if (deleteAfterWakeup) {
+    // delete waking tabs from storage
+    await deleteSnoozedTabs(tabs);
 
-  // Reschedule repeated tabs, if any
-  const periodicTabs = tabsToWakeUp.filter(tab => tab.period);
-  for (let tab of periodicTabs) {
-    await resnoozePeriodicTab(tab);
+    // Reschedule repeated tabs, if any
+    const periodicTabs = tabs.filter(tab => tab.period);
+    for (let tab of periodicTabs) {
+      await resnoozePeriodicTab(tab);
+    }
+
+    // schedule wakeup for next tabs in list
+    await scheduleWakeupAlarm('auto');
   }
 
-  // schedule wakeup for next tabs in list
-  await scheduleWakeupAlarm('auto');
-
   // re-create tabs
-  const createdTabs = await createTabs(tabsToWakeUp, makeActive);
+  const createdTabs = await createTabs(tabs, makeActive);
 
   return createdTabs;
 }
@@ -175,7 +182,7 @@ export async function handleScheduledWakeup(): Promise<void> {
 
     if (readySleepingTabs.length > 0) {
       // create inactive tabs & notify user
-      const createdTabs = await wakeupTabs(readySleepingTabs, false);
+      const createdTabs = await wakeupTabs({ tabs: readySleepingTabs, makeActive: false });
 
       // Notify user
       if (settings.showNotifications) {


### PR DESCRIPTION
## Summary
- Clicking sleeping tabs now opens them in the browser while keeping them in the snooze list
- Users can still manually delete tabs using the delete button
- Scheduled automatic wakeups continue to delete tabs as before

## Changes Made
- Refactored `wakeupTabs()` function to use modern ES6 object destructuring pattern
- Added optional `deleteAfterWakeup` parameter (defaults to `true` for backward compatibility)
- Updated `SleepingTabsPage.jsx` to pass `deleteAfterWakeup: false` when user clicks a sleeping tab
- Only runs deletion, periodic rescheduling, and alarm updates when `deleteAfterWakeup === true`

## Technical Details
**Before:**
```javascript
wakeupTabs([tab], makeTabActive)  // Always deleted tabs
```

**After:**
```javascript
wakeupTabs({ tabs: [tab], makeActive: makeTabActive, deleteAfterWakeup: false })
```

## Test Plan
- [ ] Load the extension in Chrome
- [ ] Snooze a few tabs
- [ ] Navigate to `index.html#/options/sleeping-tabs`
- [ ] Click on a sleeping tab
- [ ] Verify the tab opens in browser
- [ ] Verify the tab remains in the sleeping tabs list
- [ ] Click the delete button on a sleeping tab
- [ ] Verify the tab is removed from the list
- [ ] Wait for a scheduled wakeup alarm to trigger
- [ ] Verify scheduled tabs are still automatically deleted after opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)