### PR TITLE
Fix periodic tab loss with error handling

### DIFF
--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -176,7 +176,14 @@ export async function wakeupDeleteAndReschedule({
   console.log(`🔁 [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Found ${periodicTabs.length} periodic tabs to reschedule`);
   for (let tab of periodicTabs) {
     console.log(`🔁 [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Rescheduling periodic tab: ${tab.url}`);
-    await resnoozePeriodicTab(tab);
+    try {
+      await resnoozePeriodicTab(tab);
+    } catch {
+      console.error('Failed to resnooze periodic tab, re-adding to storage:', error);
+      const snoozedTabs = await getSnoozedTabs();
+      snoozedTabs.push(tab);
+      await saveSnoozedTabs(snoozedTabs);
+    }
   }
 
   // NOW schedule wakeup for next tabs - all storage operations complete


### PR DESCRIPTION
## Summary
- Add error handling in wakeupDeleteAndReschedule() when rescheduling periodic tabs fails
- Ensures tabs are re-added to storage for retry on the next wakeup event
- Prevents loss of snoozed tabs due to rescheduling failures

## Changes
- Modified error handling in the periodic tab rescheduling logic
- Ensures fault tolerance during tab lifecycle operations

## Test Plan
- [ ] Test periodic tab snooping with simulated errors
- [ ] Verify failed periodic tabs are properly re-stored
- [ ] Check alarm rescheduling works correctly