### PR TITLE
fix(periodic): add catch(error) for catch to execute

### DIFF
--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -184,7 +184,7 @@ export async function wakeupDeleteAndReschedule({
     console.log(`🔁 [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Rescheduling periodic tab: ${tab.url}`);
     try {
       await resnoozePeriodicTab(tab);
-    } catch {
+    } catch (error) {
       console.error('Failed to resnooze periodic tab, re-adding to storage:', error);
       const snoozedTabs = await getSnoozedTabs();
       snoozedTabs.push(tab);


### PR DESCRIPTION
I forgot to add catch(error) so that errors won't actually get caught

fix on top of https://github.com/csandapp/tab-snooze-extension-continued/pull/38, which fixes periodic tab loss with error handling
