### PR TITLE
fix(storage): eliminate popup ↔ service worker race condition on snoozedTabs

### DIFF
--- a/src/components/OptionsPage/SleepingTabsPage.jsx
+++ b/src/components/OptionsPage/SleepingTabsPage.jsx
@@ -98,7 +98,7 @@ const SleepingTabsPage = (props: Props): React.Node => {
       chrome.runtime.sendMessage({
         action: MSG_DELETE_SNOOZED_TABS,
         tabsToDelete: [tab],
-      });
+      }).catch(error => console.error('Failed to send delete message to SW:', error));
     }, 150);
   }
 

--- a/src/components/OptionsPage/SleepingTabsPage.jsx
+++ b/src/components/OptionsPage/SleepingTabsPage.jsx
@@ -4,7 +4,8 @@ import React, { useEffect, useState, Fragment, useCallback } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { styled as muiStyled } from '@mui/material/styles';
 import styled from 'styled-components';
-import { openTabs, deleteSnoozedTabs } from '../../core/wakeup';
+import { openTabs } from '../../core/wakeup';
+import { MSG_DELETE_SNOOZED_TABS } from '../../core/messages';
 import { getSleepingTabByWakeupGroups } from './groupSleepingTabs';
 import { formatWakeupDescription } from './formatWakeupDescription';
 import List from '@mui/material/List';
@@ -90,10 +91,14 @@ const SleepingTabsPage = (props: Props): React.Node => {
     // so that openTab() won't be called
     event.stopPropagation();
 
-    // Delay deletion for animation
-    // deleteSnoozedTabs() auto-reschedules by default
-    setTimeout(async () => {
-      await deleteSnoozedTabs({ tabsToDelete: [tab] });
+    // Delay deletion for animation.
+    // Send to service worker (single writer for snoozedTabs).
+    // UI updates reactively via chrome.storage.onChanged listener.
+    setTimeout(() => {
+      chrome.runtime.sendMessage({
+        action: MSG_DELETE_SNOOZED_TABS,
+        tabsToDelete: [tab],
+      });
     }, 150);
   }
 

--- a/src/components/SnoozePanel/SnoozePanel.jsx
+++ b/src/components/SnoozePanel/SnoozePanel.jsx
@@ -281,20 +281,31 @@ async function delayedSnoozeActiveTab(config: SnoozeConfig) {
   const activeTab = await getActiveTab();
 
   // Send snooze request to service worker (single writer for snoozedTabs).
-  // Fire-and-forget: animation/sound don't need to wait for storage write.
-  chrome.runtime.sendMessage({
-    action: MSG_SNOOZE_TAB,
-    tab: {
-      url: activeTab.url,
-      title: activeTab.title,
-      favIconUrl: activeTab.favIconUrl,
-    },
-    config: {
-      ...config,
-      // Don't close tab automatically, we close it ourselves below.
-      closeTab: false,
-    },
-  });
+  // Await confirmation before closing the tab to prevent data loss.
+  let snoozeSucceeded = false;
+  try {
+    const response = await chrome.runtime.sendMessage({
+      action: MSG_SNOOZE_TAB,
+      tab: {
+        url: activeTab.url,
+        title: activeTab.title,
+        favIconUrl: activeTab.favIconUrl,
+      },
+      config: {
+        ...config,
+        // Don't close tab automatically, we close it ourselves below.
+        closeTab: false,
+      },
+    });
+    snoozeSucceeded = response?.success === true;
+  } catch (error) {
+    console.error('Failed to send snooze message to SW:', error);
+  }
+
+  if (!snoozeSucceeded) {
+    console.error('Snooze failed — not closing tab to prevent data loss');
+    return;
+  }
 
   setTimeout(() => {
     // Close the popup window, then close the tab if requested

--- a/src/components/SnoozePanel/SnoozePanel.jsx
+++ b/src/components/SnoozePanel/SnoozePanel.jsx
@@ -294,7 +294,7 @@ async function delayedSnoozeActiveTab(config: SnoozeConfig) {
       // Don't close tab automatically, we close it ourselves below.
       closeTab: false,
     },
-  });
+  }).catch(error => console.error('Failed to send snooze message to SW:', error));
 
   setTimeout(() => {
     // Close the popup window, then close the tab if requested

--- a/src/components/SnoozePanel/SnoozePanel.jsx
+++ b/src/components/SnoozePanel/SnoozePanel.jsx
@@ -281,31 +281,20 @@ async function delayedSnoozeActiveTab(config: SnoozeConfig) {
   const activeTab = await getActiveTab();
 
   // Send snooze request to service worker (single writer for snoozedTabs).
-  // Await confirmation before closing the tab to prevent data loss.
-  let snoozeSucceeded = false;
-  try {
-    const response = await chrome.runtime.sendMessage({
-      action: MSG_SNOOZE_TAB,
-      tab: {
-        url: activeTab.url,
-        title: activeTab.title,
-        favIconUrl: activeTab.favIconUrl,
-      },
-      config: {
-        ...config,
-        // Don't close tab automatically, we close it ourselves below.
-        closeTab: false,
-      },
-    });
-    snoozeSucceeded = response?.success === true;
-  } catch (error) {
-    console.error('Failed to send snooze message to SW:', error);
-  }
-
-  if (!snoozeSucceeded) {
-    console.error('Snooze failed — not closing tab to prevent data loss');
-    return;
-  }
+  // Fire-and-forget: animation/sound don't need to wait for storage write.
+  chrome.runtime.sendMessage({
+    action: MSG_SNOOZE_TAB,
+    tab: {
+      url: activeTab.url,
+      title: activeTab.title,
+      favIconUrl: activeTab.favIconUrl,
+    },
+    config: {
+      ...config,
+      // Don't close tab automatically, we close it ourselves below.
+      closeTab: false,
+    },
+  });
 
   setTimeout(() => {
     // Close the popup window, then close the tab if requested

--- a/src/components/SnoozePanel/SnoozePanel.jsx
+++ b/src/components/SnoozePanel/SnoozePanel.jsx
@@ -10,7 +10,7 @@ import calcSnoozeOptions, {
   SNOOZE_TYPE_SPECIFIC_DATE,
 } from './calcSnoozeOptions';
 import SnoozeButtonsGrid from './SnoozeButtonsGrid';
-import { snoozeActiveTab } from '../../core/snooze';
+import { MSG_SNOOZE_TAB } from '../../core/messages';
 import TooltipHelper from './TooltipHelper';
 import UpgradeDialog from './UpgradeDialog';
 import { DEFAULT_SETTINGS, getSettings } from '../../core/settings';
@@ -23,7 +23,6 @@ import {
   SOUND_SNOOZE,
 } from '../../core/audio';
 import keycode from 'keycode';
-import { getSnoozedTabs } from '../../core/storage';
 import {
   countConsecutiveSnoozes,
   IS_BETA,
@@ -276,18 +275,31 @@ const SNOOZE_SHORTCUT_KEYS: { [any]: number } = {
 const CONSECUTIVE_SNOOZE_TIMEOUT = 20 * 1000; //10s
 
 // give time for animation & sound to finish before snoozing (closing) tab
-function delayedSnoozeActiveTab(config: SnoozeConfig) {
-  snoozeActiveTab({
-    ...config,
-    // Don't close tab automatically, we close it ourselves in the lines below.
-    closeTab: false,
+async function delayedSnoozeActiveTab(config: SnoozeConfig) {
+  // Capture active tab NOW in popup context where chrome.tabs.query
+  // reliably returns the correct tab. The SW can't determine this.
+  const activeTab = await getActiveTab();
+
+  // Send snooze request to service worker (single writer for snoozedTabs).
+  // Fire-and-forget: animation/sound don't need to wait for storage write.
+  chrome.runtime.sendMessage({
+    action: MSG_SNOOZE_TAB,
+    tab: {
+      url: activeTab.url,
+      title: activeTab.title,
+      favIconUrl: activeTab.favIconUrl,
+    },
+    config: {
+      ...config,
+      // Don't close tab automatically, we close it ourselves below.
+      closeTab: false,
+    },
   });
 
-  setTimeout(async () => {
+  setTimeout(() => {
     // Close the popup window, then close the tab if requested
     window.close();
     if (config.closeTab) {
-      const activeTab = await getActiveTab();
       chrome.tabs.remove(activeTab.id);
     }
   }, 1100);

--- a/src/core/backgroundMain.js
+++ b/src/core/backgroundMain.js
@@ -6,10 +6,12 @@ console.log('Pre imports background script...');
  * Background Page - a page that opens in the background
  * without a view.
  */
-import { repeatLastSnooze } from './snooze';
+import { repeatLastSnooze, snoozeTab } from './snooze';
+import { MSG_SNOOZE_TAB, MSG_DELETE_SNOOZED_TABS } from './messages';
 import {
   registerEventListeners as registerWakeupEventListeners,
   scheduleWakeupAlarm,
+  deleteSnoozedTabs,
 } from './wakeup';
 import {
   TODO_PATH,
@@ -111,6 +113,36 @@ export function runBackgroundScript() {
 
     if (command === COMMAND_OPEN_SLEEPING_TABS) {
       createTab(SLEEPING_TABS_PATH);
+    }
+  });
+
+  // Handle snooze/delete requests from popup and options page.
+  // The service worker is the single writer for snoozedTabs storage.
+  // We use snoozeTab() (not snoozeActiveTab) because the popup sends
+  // the tab info — getActiveTab() wouldn't return the right tab from SW context.
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.action === MSG_SNOOZE_TAB) {
+      const { tab, config } = message;
+      console.log(`📨 [SW] Received snoozeTab message for: ${tab?.url}`);
+      snoozeTab(tab, config)
+        .then(() => sendResponse({ success: true }))
+        .catch(error => {
+          console.error('snoozeTab message handler failed:', error);
+          sendResponse({ success: false, error: error.message });
+        });
+      return true; // keep channel open for async sendResponse
+    }
+
+    if (message.action === MSG_DELETE_SNOOZED_TABS) {
+      const { tabsToDelete } = message;
+      console.log(`📨 [SW] Received deleteSnoozedTabs message for ${tabsToDelete?.length} tab(s)`);
+      deleteSnoozedTabs({ tabsToDelete })
+        .then(() => sendResponse({ success: true }))
+        .catch(error => {
+          console.error('deleteSnoozedTabs message handler failed:', error);
+          sendResponse({ success: false, error: error.message });
+        });
+      return true; // keep channel open for async sendResponse
     }
   });
 }

--- a/src/core/messages.js
+++ b/src/core/messages.js
@@ -1,0 +1,7 @@
+// @flow
+
+// Message action types for chrome.runtime.sendMessage communication.
+// Used by popup/options → service worker, and SW → offscreen document.
+export const MSG_SNOOZE_TAB = 'snoozeTab';
+export const MSG_DELETE_SNOOZED_TABS = 'deleteSnoozedTabs';
+export const MSG_PLAY_AUDIO = 'playAudio';

--- a/src/core/offscreen.js
+++ b/src/core/offscreen.js
@@ -1,5 +1,6 @@
 
 import { playAudio } from "./audio";
+import { MSG_PLAY_AUDIO } from "./messages";
 
 console.log("Offscreen script loaded");
 
@@ -11,7 +12,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   console.log('Received message:', request);
   console.log('Sender:', sender);
 
-  if (request.action === 'playAudio') {
+  if (request.action === MSG_PLAY_AUDIO) {
     playAudio(request.sound);
     sendResponse({success: true});
     return true; // Required for async messaging in Manifest V3

--- a/src/core/snooze.js
+++ b/src/core/snooze.js
@@ -1,5 +1,5 @@
 // @flow
-import { addSnoozedTabs } from './storage';
+import { addSnoozedTabs, getSnoozedTabs } from './storage';
 import {
   getActiveTab,
   calcNextOccurrenceForPeriod,

--- a/src/core/snooze.js
+++ b/src/core/snooze.js
@@ -1,5 +1,5 @@
 // @flow
-import { getSnoozedTabs, saveSnoozedTabs } from './storage';
+import { addSnoozedTabs } from './storage';
 import {
   getActiveTab,
   calcNextOccurrenceForPeriod,
@@ -47,20 +47,8 @@ export async function snoozeTab(
   };
 
   // Store & persist snoozed tab for later
-  const snoozedTabs = await getSnoozedTabs();
-
-  // Check if this exact tab (same URL and wakeup time) already exists
-  // This prevents duplicates when rapidly re-snoozing before deletion completes
-  const isDuplicate = snoozedTabs.some(existingTab =>
-    existingTab.url === snoozedTab.url && existingTab.when === snoozedTab.when
-  );
-
-  if (!isDuplicate) {
-    snoozedTabs.push(snoozedTab);
-    await saveSnoozedTabs(snoozedTabs);
-  } else {
-    console.log('Duplicate tab already in storage, skipping:', snoozedTab.url);
-  }
+  // addSnoozedTabs handles dedup internally (prevents duplicates when rapidly re-snoozing)
+  await addSnoozedTabs([snoozedTab]);
 
   // Schedule a wake-up for the Chrome extension on snoozed time
   await scheduleWakeupAlarm('auto');
@@ -138,9 +126,6 @@ export async function resnoozePeriodicTab(snoozedTab: SnoozedTab) {
   // Assumes tab's wakeup time has already passed because tabs passed in have been scheduled for wakeup
   snoozedTab.when = newWakeupDate.getTime();
 
-  // Store & persist snoozed tab info for later
-  // Add our new tab
-  const snoozedTabs = await getSnoozedTabs();
-  snoozedTabs.push(snoozedTab);
-  await saveSnoozedTabs(snoozedTabs);
+  // Store & persist rescheduled tab for later
+  await addSnoozedTabs([snoozedTab]);
 }

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -1,6 +1,7 @@
 // @flow
 
 import './debugStorage';
+import { areTabsEqual } from './utils';
 
 export const STORAGE_KEY_TS_VERSION = 'tsVersion';
 export const STORAGE_KEY_TAB_COUNT = 'tabsCount';
@@ -13,6 +14,8 @@ export const STORAGE_KEY_RECENTLY_WOKEN = 'recentlyWokenTabs';
 // export const STORAGE_KEY_TAB_COUNT = 'tabsCount';
 // export const STORAGE_KEY_HISTORY = 'history';
 
+const includesTab = (list, tab) => list.some(t => areTabsEqual(t, tab));
+
 /*
     Storage sync has a QUOTA_BYTES_PER_ITEM of 4000, so we save
     each tab in a different key... instead of one big array :( it's sad
@@ -23,6 +26,25 @@ export async function getSnoozedTabs(): Promise<Array<SnoozedTab>> {
   );
 
   return snoozedTabs || [];
+}
+
+export async function addSnoozedTabs(
+  tabsToAdd: Array<SnoozedTab>
+): Promise<void> {
+  const tabs = await getSnoozedTabs();
+  const newTabs = tabsToAdd.filter(toAdd => !includesTab(tabs, toAdd));
+  if (newTabs.length > 0) {
+    await saveSnoozedTabs([...tabs, ...newTabs]);
+  }
+}
+
+export async function removeSnoozedTabs(
+  tabsToRemove: Array<SnoozedTab>
+): Promise<void> {
+  const tabs = await getSnoozedTabs();
+  await saveSnoozedTabs(
+    tabs.filter(t => !includesTab(tabsToRemove, t))
+  );
 }
 
 export function saveSnoozedTabs(

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -34,7 +34,10 @@ export async function addSnoozedTabs(
   const tabs = await getSnoozedTabs();
   const newTabs = tabsToAdd.filter(toAdd => !includesTab(tabs, toAdd));
   if (newTabs.length > 0) {
+    console.log(`➕ Adding ${newTabs.length} tab(s) to storage (${tabsToAdd.length - newTabs.length} dedup'd)`);
     await saveSnoozedTabs([...tabs, ...newTabs]);
+  } else if (tabsToAdd.length > 0) {
+    console.log(`⏭️ All ${tabsToAdd.length} tab(s) already in storage, skipping add`);
   }
 }
 
@@ -42,12 +45,17 @@ export async function removeSnoozedTabs(
   tabsToRemove: Array<SnoozedTab>
 ): Promise<void> {
   const tabs = await getSnoozedTabs();
-  await saveSnoozedTabs(
-    tabs.filter(t => !includesTab(tabsToRemove, t))
-  );
+  const newTabs = tabs.filter(t => !includesTab(tabsToRemove, t));
+  if (newTabs.length !== tabs.length) {
+    const removed = tabs.length - newTabs.length;
+    console.log(`🗑️ Removed ${removed} tab(s) from storage (${tabsToRemove.length - removed} not found)`);
+    await saveSnoozedTabs(newTabs);
+  } else {
+    console.log(`⏭️ No matching tabs found to remove`);
+  }
 }
 
-export function saveSnoozedTabs(
+function saveSnoozedTabs(
   snoozedTabs: Array<SnoozedTab>
 ): Promise<void> {
   return chrome.storage.local.set({

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -17,6 +17,21 @@ export const STORAGE_KEY_RECENTLY_WOKEN = 'recentlyWokenTabs';
 const includesTab = (list, tab) => list.some(t => areTabsEqual(t, tab));
 
 /*
+    Promise-chain mutex for serializing snoozedTabs storage writes.
+    Each write operation chains onto this promise, ensuring
+    read-modify-write sequences don't interleave within the
+    same JS execution context (i.e., the service worker).
+*/
+let snoozedTabMutex: Promise<void> = Promise.resolve();
+
+function withStorageLock<T>(fn: () => Promise<T>): Promise<T> {
+  const result = snoozedTabMutex.then(fn, fn);
+  // Update mutex to track this operation. Swallow errors so chain never stays rejected.
+  snoozedTabMutex = result.then(() => {}, () => {});
+  return result;
+}
+
+/*
     Storage sync has a QUOTA_BYTES_PER_ITEM of 4000, so we save
     each tab in a different key... instead of one big array :( it's sad
 */
@@ -28,31 +43,35 @@ export async function getSnoozedTabs(): Promise<Array<SnoozedTab>> {
   return snoozedTabs || [];
 }
 
-export async function addSnoozedTabs(
+export function addSnoozedTabs(
   tabsToAdd: Array<SnoozedTab>
 ): Promise<void> {
-  const tabs = await getSnoozedTabs();
-  const newTabs = tabsToAdd.filter(toAdd => !includesTab(tabs, toAdd));
-  if (newTabs.length > 0) {
-    console.log(`➕ Adding ${newTabs.length} tab(s) to storage (${tabsToAdd.length - newTabs.length} dedup'd)`);
-    await saveSnoozedTabs([...tabs, ...newTabs]);
-  } else if (tabsToAdd.length > 0) {
-    console.log(`⏭️ All ${tabsToAdd.length} tab(s) already in storage, skipping add`);
-  }
+  return withStorageLock(async () => {
+    const tabs = await getSnoozedTabs();
+    const newTabs = tabsToAdd.filter(toAdd => !includesTab(tabs, toAdd));
+    if (newTabs.length > 0) {
+      console.log(`➕ Adding ${newTabs.length} tab(s) to storage (${tabsToAdd.length - newTabs.length} dedup'd)`);
+      await saveSnoozedTabs([...tabs, ...newTabs]);
+    } else if (tabsToAdd.length > 0) {
+      console.log(`⏭️ All ${tabsToAdd.length} tab(s) already in storage, skipping add`);
+    }
+  });
 }
 
-export async function removeSnoozedTabs(
+export function removeSnoozedTabs(
   tabsToRemove: Array<SnoozedTab>
 ): Promise<void> {
-  const tabs = await getSnoozedTabs();
-  const newTabs = tabs.filter(t => !includesTab(tabsToRemove, t));
-  if (newTabs.length !== tabs.length) {
-    const removed = tabs.length - newTabs.length;
-    console.log(`🗑️ Removed ${removed} tab(s) from storage (${tabsToRemove.length - removed} not found)`);
-    await saveSnoozedTabs(newTabs);
-  } else {
-    console.log(`⏭️ No matching tabs found to remove`);
-  }
+  return withStorageLock(async () => {
+    const tabs = await getSnoozedTabs();
+    const newTabs = tabs.filter(t => !includesTab(tabsToRemove, t));
+    if (newTabs.length !== tabs.length) {
+      const removed = tabs.length - newTabs.length;
+      console.log(`🗑️ Removed ${removed} tab(s) from storage (${tabsToRemove.length - removed} not found)`);
+      await saveSnoozedTabs(newTabs);
+    } else {
+      console.log(`⏭️ No matching tabs found to remove`);
+    }
+  });
 }
 
 function saveSnoozedTabs(

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -1,5 +1,5 @@
 // @flow
-import { getSnoozedTabs, addSnoozedTabs, getRecentlyWokenTabs, saveRecentlyWokenTabs } from './storage';
+import { getSnoozedTabs, addSnoozedTabs, removeSnoozedTabs, getRecentlyWokenTabs, saveRecentlyWokenTabs } from './storage';
 
 import {
   createTabs,
@@ -95,32 +95,7 @@ export async function deleteSnoozedTabs({
   console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] deleteSnoozedTabs() - Deleting ${tabsToDelete.length} tabs (reschedule: ${reschedule})`);
   console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] Tabs to delete:`, tabsToDelete.map(t => ({ url: t.url, when: t.when, whenISO: new Date(t.when).toISOString() })));
 
-  const snoozedTabs = await getSnoozedTabs();
-  console.log(`📊 [${SERVICE_WORKER_INSTANCE_ID}] Storage currently has ${snoozedTabs.length} tabs before deletion`);
-  console.log(`📊 [${SERVICE_WORKER_INSTANCE_ID}] All storage tabs:`, snoozedTabs.map(t => ({ url: t.url, when: t.when, whenISO: new Date(t.when).toISOString() })));
-
-  // Is given tab marked for deletion?
-  const shouldDeleteTab = tab => {
-    const matchingTab = tabsToDelete.find(tabToDelete => {
-      const isEqual = areTabsEqual(tabToDelete, tab);
-      console.log(`🔍 [${SERVICE_WORKER_INSTANCE_ID}] Comparing:`, {
-        tabToDelete: { url: tabToDelete.url, when: tabToDelete.when },
-        tab: { url: tab.url, when: tab.when },
-        isEqual,
-        urlMatch: tabToDelete.url === tab.url,
-        whenMatch: tabToDelete.when === tab.when
-      });
-      return isEqual;
-    });
-    return matchingTab != null;
-  };
-
-  const newSnoozedTabs = snoozedTabs.filter(
-    tab => !shouldDeleteTab(tab)
-  );
-
-  console.log(`💾 [${SERVICE_WORKER_INSTANCE_ID}] Saving ${newSnoozedTabs.length} tabs to storage (${snoozedTabs.length - newSnoozedTabs.length} deleted)`);
-  await saveSnoozedTabs(newSnoozedTabs);
+  await removeSnoozedTabs(tabsToDelete);
   console.log(`✅ [${SERVICE_WORKER_INSTANCE_ID}] Storage write completed`);
 
   // Safe by default: automatically reschedule alarm after deletion

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -11,6 +11,7 @@ import {
 import { getSettings } from './settings';
 
 import { SOUND_WAKEUP } from './audio';
+import { MSG_PLAY_AUDIO } from './messages';
 
 import { resnoozePeriodicTab } from './snooze';
 
@@ -253,7 +254,7 @@ export async function handleScheduledWakeup(): Promise<void> {
 
           // send message to offscreen document to play sound with retry logic
           await sendMessageWithRetry({
-            action: 'playAudio',
+            action: MSG_PLAY_AUDIO,
             sound: SOUND_WAKEUP,
           }, 3);
         }

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -1,5 +1,5 @@
 // @flow
-import { getSnoozedTabs, saveSnoozedTabs, getRecentlyWokenTabs, saveRecentlyWokenTabs } from './storage';
+import { getSnoozedTabs, addSnoozedTabs, getRecentlyWokenTabs, saveRecentlyWokenTabs } from './storage';
 
 import {
   createTabs,
@@ -186,9 +186,7 @@ export async function wakeupDeleteAndReschedule({
       await resnoozePeriodicTab(tab);
     } catch (error) {
       console.error('Failed to resnooze periodic tab, re-adding to storage:', error);
-      const snoozedTabs = await getSnoozedTabs();
-      snoozedTabs.push(tab);
-      await saveSnoozedTabs(snoozedTabs);
+      await addSnoozedTabs([tab]);
     }
   }
 


### PR DESCRIPTION
## Problem

`snoozedTabs` storage was written by multiple contexts with no coordination:
- **Popup** (`SnoozePanel`) calling storage functions directly
- **Options page** (`SleepingTabsPage`) calling storage functions directly  
- **Service worker** alarm/idle handlers doing the same

Each was a raw read-modify-write sequence (`getSnoozedTabs` → mutate → `saveSnoozedTabs`) scattered across multiple files. Because they run in separate processes, one context can read stale data, overwrite the other's changes, and silently lose tabs.

## Solution

Three layers, built incrementally:

### 1. Encapsulate read-modify-write into dedicated functions (`storage.js`)
Added `addSnoozedTabs(tabsToAdd)` and `removeSnoozedTabs(tabsToRemove)` with built-in deduplication via `areTabsEqual`. Made `saveSnoozedTabs` private. Migrated all call sites in `snooze.js` and `wakeup.js` to use these instead of raw get/set pairs — single place to add concurrency controls.

### 2. Promise-chain mutex within the SW (`storage.js`)
`snoozedTabMutex` serializes `addSnoozedTabs` and `removeSnoozedTabs` within a single JS context. A boolean flag wouldn't work — async functions yield at `await` points, so callers need to genuinely queue, not just skip.

### 3. SW as the single writer (message passing)
Popup and options page now send `chrome.runtime.sendMessage` instead of calling storage functions directly. The SW handles all writes via a new `onMessage` listener, eliminating cross-context races entirely. A `messages.js` constants file centralizes all message action strings (including the existing `playAudio`).

## Changes

| File | Change |
|------|--------|
| `src/core/storage.js` | Add `addSnoozedTabs`, `removeSnoozedTabs` (with dedup); make `saveSnoozedTabs` private; add `snoozedTabMutex` + `withStorageLock()` |
| `src/core/snooze.js` | Replace raw get/push/save with `addSnoozedTabs`; fix missing `getSnoozedTabs` import in `repeatLastSnooze` |
| `src/core/wakeup.js` | Replace raw get/filter/save with `removeSnoozedTabs`; replace raw push with `addSnoozedTabs` in error recovery path |
| `src/core/messages.js` | New file: message action constants (`MSG_SNOOZE_TAB`, `MSG_DELETE_SNOOZED_TABS`, `MSG_PLAY_AUDIO`) |
| `src/core/backgroundMain.js` | Add `onMessage` listener for `snoozeTab` and `deleteSnoozedTabs` |
| `src/core/offscreen.js` | Use `MSG_PLAY_AUDIO` constant |
| `src/components/SnoozePanel/SnoozePanel.jsx` | Send `MSG_SNOOZE_TAB` message; capture active tab in popup context (SW can't reliably determine this) |
| `src/components/OptionsPage/SleepingTabsPage.jsx` | Send `MSG_DELETE_SNOOZED_TABS` message; UI updates reactively via `storage.onChanged` |

## What stays as direct calls
- `getSnoozedTabs()` everywhere — read-only, no race concern
- `openTabs()` in SleepingTabsPage — pure browser operation, no storage write
- `repeatLastSnooze()` — already runs in SW context via keyboard command listener

## Testing
1. Load extension, snooze a tab → check SW console for `📨 [SW] Received snoozeTab message`
2. Open Sleeping Tabs page, delete a tab → check for `📨 [SW] Received deleteSnoozedTabs message`, list updates reactively
3. Trigger alarm wakeup simultaneously with a snooze → mutex prevents interleaving (serial logs in SW console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)