### PR TITLE
fix(wakeup): add keepalive alarm to recover tabs after sleep

### DIFF
--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -21,6 +21,7 @@ import { ensureOffscreenDocument } from "./backgroundMain";
 
 
 const WAKEUP_TABS_ALARM_NAME = 'WAKEUP_TABS_ALARM';
+const KEEPALIVE_CHECK_ALARM_NAME = 'KEEPALIVE_CHECK';
 
 // Generate a unique ID for this service worker instance to track restarts
 const SERVICE_WORKER_INSTANCE_ID = `SW-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
@@ -316,7 +317,24 @@ export function registerEventListeners(): void {
       // handleScheduledWakeup() → wakeupDeleteAndReschedule() already calls scheduleWakeupAlarm('auto'),
       // so scheduling here would create duplicate alarms and cause tabs to wake up twice.
     }
+
+    if (alarm.name === KEEPALIVE_CHECK_ALARM_NAME) {
+      // Safety net: periodic check for overdue tabs.
+      // Catches cases where the one-shot alarm was cancelled during sleep
+      // and idle.onStateChanged didn't fire reliably to reschedule it.
+      const state = await chrome.idle.queryState(60);
+      console.log(`🔄 [${SERVICE_WORKER_INSTANCE_ID}] Keepalive check - user state: ${state}`);
+      if (state === 'active') {
+        await handleScheduledWakeup();
+      }
+    }
   });
+
+  // Periodic keepalive: safety net that survives sleep/wake cycles.
+  // Chrome persists periodic alarms independently of the SW lifecycle and
+  // fires overdue ones when the system wakes, restarting the SW automatically.
+  // This ensures overdue tabs are always caught even if idle.onStateChanged doesn't fire.
+  chrome.alarms.create(KEEPALIVE_CHECK_ALARM_NAME, { periodInMinutes: 1 });
 
   /*
     After computer sleeps and then wakes, for some reason


### PR DESCRIPTION
## Summary
- After computer sleep, the one-shot wakeup alarm is cancelled on idle and `chrome.idle.onStateChanged` may not reliably restart the service worker — leaving snoozed tabs stuck with no alarm to wake them
- Adds a periodic `KEEPALIVE_CHECK` alarm that persists in Chrome's alarm scheduler independently of the SW lifecycle. Chrome fires overdue periodic alarms on wake, restarting the SW automatically
- Only opens tabs when the user is actively using the computer (`chrome.idle.queryState`) to avoid tabs popping open during lock screen

## Test plan
- [ ] Build and load the extension
- [ ] Snooze a tab for ~2 minutes from now
- [ ] Put computer to sleep, wait past the snooze time, wake computer
- [ ] Verify the tab opens within ~1 minute of waking (check for `Keepalive check` logs in SW console)
- [ ] Verify tabs do NOT open while screen is locked (keepalive checks idle state)
- [ ] Change `periodInMinutes` to 10 before shipping to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)