### PR TITLE
fix: partial tab create failure no longer blocks entire wakeup batch

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -30,25 +30,35 @@ export function isMacOS() {
 export function createTabs(
   tabInfos: Array<SnoozedTab>,
   makeActive: boolean
-): Promise<Array<ChromeTab>> {
+): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab> }> {
   // Generate a unique call ID to track this specific invocation
   const callId = `CT-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
 
   console.log(`🌐 [${callId}] createTabs() CALLED with ${tabInfos.length} tabs, makeActive: ${makeActive}`);
   console.log(`🌐 [${callId}] Tab URLs:`, tabInfos.map(t => t.url));
 
-  const allTabsCreatedPromise = Promise.all(
-    tabInfos.map((tabInfo, index) => {
+  return Promise.allSettled(
+    tabInfos.map((tabInfo) => {
       return chrome.tabs.create({
         url: tabInfo.url, // attachAffiliationTag(tabInfo.url),
         active: makeActive,
       });
     })
-  );
+  ).then(results => {
+    const created = [];
+    const failedTabs = [];
 
-  return allTabsCreatedPromise.then(tabs => {
-    console.log(`✅ [${callId}] createTabs() COMPLETED - Created ${tabs.length} tabs`);
-    return tabs;
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        created.push(result.value);
+      } else {
+        console.warn(`⚠️ [${callId}] Failed to create tab: ${tabInfos[index].url}`, result.reason);
+        failedTabs.push(tabInfos[index]);
+      }
+    });
+
+    console.log(`✅ [${callId}] createTabs() done: ${created.length} created, ${failedTabs.length} failed`);
+    return { created, failedTabs };
   });
 }
 

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -229,23 +229,26 @@ export async function handleScheduledWakeup(): Promise<void> {
         await saveRecentlyWokenTabs([]);
 
         // Notify user (non-critical - OK if this fails)
-        if (settings.showNotifications) {
-          // Show desktop notification
-          notifyUserAboutNewTabs(readySleepingTabs, createdTabs[0]);
-        }
+        // Skip if no tabs were actually created (all failed)
+        if (createdTabs.length > 0) {
+          if (settings.showNotifications) {
+            // Show desktop notification
+            notifyUserAboutNewTabs(readySleepingTabs, createdTabs[0]);
+          }
 
-        if (settings.playNotificationSound) {
-          console.log(`🔊 [${SERVICE_WORKER_INSTANCE_ID}] Playing notification sound...`);
-          // Note: handleScheduledWakeup() is ONLY called in background script
+          if (settings.playNotificationSound) {
+            console.log(`🔊 [${SERVICE_WORKER_INSTANCE_ID}] Playing notification sound...`);
+            // Note: handleScheduledWakeup() is ONLY called in background script
 
-          // ensure offscreen document is created
-          await ensureOffscreenDocument();
+            // ensure offscreen document is created
+            await ensureOffscreenDocument();
 
-          // send message to offscreen document to play sound with retry logic
-          await sendMessageWithRetry({
-            action: MSG_PLAY_AUDIO,
-            sound: SOUND_WAKEUP,
-          }, 3);
+            // send message to offscreen document to play sound with retry logic
+            await sendMessageWithRetry({
+              action: MSG_PLAY_AUDIO,
+              sound: SOUND_WAKEUP,
+            }, 3);
+          }
         }
       } catch (error) {
         // Log error for debugging

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -136,21 +136,23 @@ export async function wakeupDeleteAndReschedule({
 
   // Create tabs FIRST to prevent data loss if crash occurs
   // If we crash after delete but before create, tabs are lost forever
-  const createdTabs = await openTabs({ tabs, makeActive });
+  const { created: createdTabs, failedTabs } = await openTabs({ tabs, makeActive });
+
+  // Only delete tabs that were successfully opened — failed tabs stay in storage for retry
+  const successfulTabs = tabs.filter(tab => !failedTabs.includes(tab));
 
   // Delete from storage AFTER tabs are created
   // Pass scheduleAlarm=false because we need to handle periodic tabs first
-
   //
   // ORDER MATTERS: Delete BEFORE rescheduling periodic tabs.
   // resnoozePeriodicTab() updates the in-memory tab object with a new `when`,
   // then pushes it to storage as a fresh entry. If we rescheduled first,
   // deleteSnoozedTabs() would match and remove the newly created entry.
-  console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Deleting tabs from storage...`);
-  await deleteSnoozedTabs({ tabsToDelete: tabs, scheduleAlarm: false });
+  console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Deleting ${successfulTabs.length} tabs from storage (${failedTabs.length} failed, kept)...`);
+  await deleteSnoozedTabs({ tabsToDelete: successfulTabs, scheduleAlarm: false });
 
-  // Reschedule repeated tabs, if any
-  const periodicTabs = tabs.filter(tab => tab.period);
+  // Reschedule repeated tabs that succeeded — failed periodic tabs stay as-is for retry
+  const periodicTabs = successfulTabs.filter(tab => tab.period);
   console.log(`🔁 [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Found ${periodicTabs.length} periodic tabs to reschedule`);
   for (let tab of periodicTabs) {
     console.log(`🔁 [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Rescheduling periodic tab: ${tab.url}`);

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -115,11 +115,11 @@ export async function openTabs({
 }: {
   tabs: Array<SnoozedTab>,
   makeActive?: boolean,
-}): Promise<Array<ChromeTab>> {
-  const createdTabs = await createTabs(tabs, makeActive);
-  console.log(`✅ [${SERVICE_WORKER_INSTANCE_ID}] openTabs() - Created ${createdTabs.length} browser tabs successfully`);
+}): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab> }> {
+  const result = await createTabs(tabs, makeActive);
+  console.log(`✅ [${SERVICE_WORKER_INSTANCE_ID}] openTabs() - Created ${result.created.length} browser tabs, ${result.failedTabs.length} failed`);
 
-  return createdTabs;
+  return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- `createTabs()` used `Promise.all()`, so a single `chrome.tabs.create()` failure (e.g. `file://` URL without local file access permission) would reject the entire batch — preventing **all** tabs from being deleted from storage, even ones that opened successfully
- This caused duplicate tab opens on every subsequent alarm, since successfully-opened tabs were never cleaned up
- Switched to `Promise.allSettled()` so each tab is handled independently: successful tabs get deleted from storage, failed tabs stay for retry

## Repro (before fix)
1. Disable "Allow access to file URLs" in extension settings
2. Snooze a `file://` URL and a normal `https://` URL together
3. Wait for alarm — both tabs stay in the sleeping tabs list
4. On next alarm, the `https://` tab opens again (duplicate)

## Test plan
- [ ] Snooze a `file://` URL + `https://` URL with file access disabled → only `https://` tab removed from list
- [ ] Snooze multiple `https://` tabs → all open and removed as before
- [ ] Verify no notification/sound when all tabs fail
- [ ] Verify periodic tabs only reschedule if they opened successfully