### PR TITLE
Release 12.1.1: Fix snoozed tabs re-opening repeatedly

### DIFF
--- a/public/manifest.dev.json
+++ b/public/manifest.dev.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Tab Snooze - Manifest V3",
   "short_name": "Tab Snooze",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "description": "Save articles, videos and todos for later. They'll magically reopen when you need them.",
   "icons": { "128": "images/extension_icon_128.png" },
   "author": "csandapp",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Tab Snooze - Manifest V3",
   "short_name": "Tab Snooze",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "description": "Save articles, videos and todos for later. They'll magically reopen when you need them.",
   "icons": { "128": "images/extension_icon_128.png" },
   "author": "csandapp",

--- a/src/components/dialogs/WhatsNewDialog.jsx
+++ b/src/components/dialogs/WhatsNewDialog.jsx
@@ -11,10 +11,7 @@ import CodeIcon from '@mui/icons-material/Code';
 import congratsImage from './images/congrats.png';
 
 const CHANGELOG_ITEMS = [
-  'Fixed tabs opening multiple times',
-  'Open sleeping tabs without removing them from the list',
-  'Snooze times are now rounded to the exact minute',
-  'Upgraded to React 18',
+  'Fixed a bug where snoozed tabs could re-open repeatedly',
 ];
 
 export default function WhatsNewDialog(): React.Node {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -30,7 +30,7 @@ export function isMacOS() {
 export function createTabs(
   tabInfos: Array<SnoozedTab>,
   makeActive: boolean
-): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab> }> {
+): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab>, customHandled: Array<SnoozedTab> }> {
   // Generate a unique call ID to track this specific invocation
   const callId = `CT-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
 
@@ -47,18 +47,24 @@ export function createTabs(
   ).then(results => {
     const created = [];
     const failedTabs = [];
+    const customHandled = [];
 
     results.forEach((result, index) => {
       if (result.status === 'fulfilled') {
         created.push(result.value);
+      } else if (result.reason?.message?.includes('handled by Atlas')) {
+        // Some browsers (e.g. Atlas) physically open the tab but reject the promise.
+        // Not a real failure — tab is open, just no ChromeTab object returned.
+        customHandled.push(tabInfos[index]);
+        console.log(`ℹ️ [${callId}] Tab handled externally: ${tabInfos[index].url}`, result.reason?.message);
       } else {
         console.warn(`⚠️ [${callId}] Failed to create tab: ${tabInfos[index].url}`, result.reason);
         failedTabs.push(tabInfos[index]);
       }
     });
 
-    console.log(`✅ [${callId}] createTabs() done: ${created.length} created, ${failedTabs.length} failed`);
-    return { created, failedTabs };
+    console.log(`✅ [${callId}] createTabs() done: ${created.length} created, ${customHandled.length} externally handled, ${failedTabs.length} failed`);
+    return { created, failedTabs, customHandled };
   });
 }
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -30,25 +30,35 @@ export function isMacOS() {
 export function createTabs(
   tabInfos: Array<SnoozedTab>,
   makeActive: boolean
-): Promise<Array<ChromeTab>> {
+): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab> }> {
   // Generate a unique call ID to track this specific invocation
   const callId = `CT-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
 
   console.log(`🌐 [${callId}] createTabs() CALLED with ${tabInfos.length} tabs, makeActive: ${makeActive}`);
   console.log(`🌐 [${callId}] Tab URLs:`, tabInfos.map(t => t.url));
 
-  const allTabsCreatedPromise = Promise.all(
-    tabInfos.map((tabInfo, index) => {
+  return Promise.allSettled(
+    tabInfos.map((tabInfo) => {
       return chrome.tabs.create({
         url: tabInfo.url, // attachAffiliationTag(tabInfo.url),
         active: makeActive,
       });
     })
-  );
+  ).then(results => {
+    const created = [];
+    const failedTabs = [];
 
-  return allTabsCreatedPromise.then(tabs => {
-    console.log(`✅ [${callId}] createTabs() COMPLETED - Created ${tabs.length} tabs`);
-    return tabs;
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        created.push(result.value);
+      } else {
+        console.warn(`⚠️ [${callId}] Failed to create tab: ${tabInfos[index].url}`, result.reason);
+        failedTabs.push(tabInfos[index]);
+      }
+    });
+
+    console.log(`✅ [${callId}] createTabs() done: ${created.length} created, ${failedTabs.length} failed`);
+    return { created, failedTabs };
   });
 }
 

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -115,9 +115,9 @@ export async function openTabs({
 }: {
   tabs: Array<SnoozedTab>,
   makeActive?: boolean,
-}): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab> }> {
+}): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab>, customHandled: Array<SnoozedTab> }> {
   const result = await createTabs(tabs, makeActive);
-  console.log(`✅ [${SERVICE_WORKER_INSTANCE_ID}] openTabs() - Created ${result.created.length} browser tabs, ${result.failedTabs.length} failed`);
+  console.log(`✅ [${SERVICE_WORKER_INSTANCE_ID}] openTabs() - Created ${result.created.length} browser tabs, ${result.customHandled.length} externally handled, ${result.failedTabs.length} failed`);
 
   return result;
 }
@@ -136,7 +136,7 @@ export async function wakeupDeleteAndReschedule({
 
   // Create tabs FIRST to prevent data loss if crash occurs
   // If we crash after delete but before create, tabs are lost forever
-  const { created: createdTabs, failedTabs } = await openTabs({ tabs, makeActive });
+  const { created: createdTabs, failedTabs, customHandled } = await openTabs({ tabs, makeActive });
 
   // Only delete tabs that were successfully opened — failed tabs stay in storage for retry
   const successfulTabs = tabs.filter(tab => !failedTabs.includes(tab));
@@ -148,7 +148,7 @@ export async function wakeupDeleteAndReschedule({
   // resnoozePeriodicTab() updates the in-memory tab object with a new `when`,
   // then pushes it to storage as a fresh entry. If we rescheduled first,
   // deleteSnoozedTabs() would match and remove the newly created entry.
-  console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Deleting ${successfulTabs.length} tabs from storage (${failedTabs.length} failed, kept)...`);
+  console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Deleting ${successfulTabs.length} tabs from storage (${customHandled.length} externally handled, ${failedTabs.length} failed, kept)...`);
   await deleteSnoozedTabs({ tabsToDelete: successfulTabs, scheduleAlarm: false });
 
   // Reschedule repeated tabs that succeeded — failed periodic tabs stay as-is for retry

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -229,23 +229,26 @@ export async function handleScheduledWakeup(): Promise<void> {
         await saveRecentlyWokenTabs([]);
 
         // Notify user (non-critical - OK if this fails)
-        if (settings.showNotifications) {
-          // Show desktop notification
-          notifyUserAboutNewTabs(readySleepingTabs, createdTabs[0]);
-        }
+        // Skip if no tabs were actually created (all failed)
+        if (createdTabs.length > 0) {
+          if (settings.showNotifications) {
+            // Show desktop notification
+            notifyUserAboutNewTabs(readySleepingTabs, createdTabs[0]);
+          }
 
-        if (settings.playNotificationSound) {
-          console.log(`🔊 [${SERVICE_WORKER_INSTANCE_ID}] Playing notification sound...`);
-          // Note: handleScheduledWakeup() is ONLY called in background script
+          if (settings.playNotificationSound) {
+            console.log(`🔊 [${SERVICE_WORKER_INSTANCE_ID}] Playing notification sound...`);
+            // Note: handleScheduledWakeup() is ONLY called in background script
 
-          // ensure offscreen document is created
-          await ensureOffscreenDocument();
+            // ensure offscreen document is created
+            await ensureOffscreenDocument();
 
-          // send message to offscreen document to play sound with retry logic
-          await sendMessageWithRetry({
-            action: MSG_PLAY_AUDIO,
-            sound: SOUND_WAKEUP,
-          }, 3);
+            // send message to offscreen document to play sound with retry logic
+            await sendMessageWithRetry({
+              action: MSG_PLAY_AUDIO,
+              sound: SOUND_WAKEUP,
+            }, 3);
+          }
         }
       } catch (error) {
         // Log error for debugging

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -136,21 +136,23 @@ export async function wakeupDeleteAndReschedule({
 
   // Create tabs FIRST to prevent data loss if crash occurs
   // If we crash after delete but before create, tabs are lost forever
-  const createdTabs = await openTabs({ tabs, makeActive });
+  const { created: createdTabs, failedTabs } = await openTabs({ tabs, makeActive });
+
+  // Only delete tabs that were successfully opened — failed tabs stay in storage for retry
+  const successfulTabs = tabs.filter(tab => !failedTabs.includes(tab));
 
   // Delete from storage AFTER tabs are created
   // Pass scheduleAlarm=false because we need to handle periodic tabs first
-
   //
   // ORDER MATTERS: Delete BEFORE rescheduling periodic tabs.
   // resnoozePeriodicTab() updates the in-memory tab object with a new `when`,
   // then pushes it to storage as a fresh entry. If we rescheduled first,
   // deleteSnoozedTabs() would match and remove the newly created entry.
-  console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Deleting tabs from storage...`);
-  await deleteSnoozedTabs({ tabsToDelete: tabs, scheduleAlarm: false });
+  console.log(`🗑️ [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Deleting ${successfulTabs.length} tabs from storage (${failedTabs.length} failed, kept)...`);
+  await deleteSnoozedTabs({ tabsToDelete: successfulTabs, scheduleAlarm: false });
 
-  // Reschedule repeated tabs, if any
-  const periodicTabs = tabs.filter(tab => tab.period);
+  // Reschedule repeated tabs that succeeded — failed periodic tabs stay as-is for retry
+  const periodicTabs = successfulTabs.filter(tab => tab.period);
   console.log(`🔁 [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Found ${periodicTabs.length} periodic tabs to reschedule`);
   for (let tab of periodicTabs) {
     console.log(`🔁 [${SERVICE_WORKER_INSTANCE_ID}] wakeupDeleteAndReschedule() - Rescheduling periodic tab: ${tab.url}`);

--- a/src/core/wakeup.js
+++ b/src/core/wakeup.js
@@ -115,11 +115,11 @@ export async function openTabs({
 }: {
   tabs: Array<SnoozedTab>,
   makeActive?: boolean,
-}): Promise<Array<ChromeTab>> {
-  const createdTabs = await createTabs(tabs, makeActive);
-  console.log(`✅ [${SERVICE_WORKER_INSTANCE_ID}] openTabs() - Created ${createdTabs.length} browser tabs successfully`);
+}): Promise<{ created: Array<ChromeTab>, failedTabs: Array<SnoozedTab> }> {
+  const result = await createTabs(tabs, makeActive);
+  console.log(`✅ [${SERVICE_WORKER_INSTANCE_ID}] openTabs() - Created ${result.created.length} browser tabs, ${result.failedTabs.length} failed`);
 
-  return createdTabs;
+  return result;
 }
 
 /*


### PR DESCRIPTION
## Summary

**Bug Fix: Snoozed tabs re-opening repeatedly**

- **PR #50:** `createTabs()` used `Promise.all()`, so a single `chrome.tabs.create()` failure (e.g. `file://` URL without local file access permission) would reject the entire batch — preventing all tabs from being deleted from storage, even ones that opened successfully. This caused duplicate tab opens on every subsequent alarm. Switched to `Promise.allSettled()` so each tab is handled independently: successful tabs get deleted from storage, failed tabs stay for retry. Notifications/sound suppressed when no tabs opened.
- **PR #52:** Atlas browser physically opens tabs but rejects the `chrome.tabs.create()` promise with error "tabs.create handled by Atlas but created tab was not resolved". Previously, this rejection caused the entire wakeup flow to fail — tabs stayed in storage and re-opened on every alarm. Now detects Atlas rejections in `createTabs()` via the "handled by Atlas" error message and tracks them in a new `customHandled` array (not `failedTabs`), so they get deleted from storage correctly. Logs at info level instead of warning since this is expected Atlas behavior.

## Test plan
- [x] Tested locally — both PR fixes verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)