### PR TITLE
feat(build): inject git commit info into builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from 'vite'
+import { execSync } from 'child_process'
+import { writeFileSync } from 'fs'
 import react from '@vitejs/plugin-react'
 import { crx } from '@crxjs/vite-plugin'
 import { resolve } from 'path'
@@ -8,6 +10,10 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 import manifest from './public/manifest.json'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
+
+const gitHash = execSync('git rev-parse --short HEAD').toString().trim()
+const gitCommitMsg = execSync('git log -1 --pretty=%s').toString().trim()
+const gitDirty = execSync('git status --porcelain').toString().trim() !== ''
 
 export default defineConfig({
   plugins: [
@@ -19,7 +25,20 @@ export default defineConfig({
       }
     }),
     crx({ manifest }),
-    tsconfigPaths()
+    tsconfigPaths(),
+    {
+      name: 'build-info',
+      closeBundle() {
+        const info = [
+          `Commit: ${gitHash}`,
+          `Message: ${gitCommitMsg}`,
+          `Dirty: ${gitDirty ? 'yes' : 'no'}`,
+          `Built: ${new Date().toISOString()}`,
+        ].join('\n')
+        writeFileSync('build/build-info.txt', info + '\n')
+        console.log('\n📦 Build Info:\n' + info + '\n')
+      }
+    }
   ],
 
   esbuild: {


### PR DESCRIPTION
## Summary
- Capture git hash, commit message, and dirty status at build time via `execSync` in Vite config
- Add `build-info` Vite plugin that writes `build/build-info.txt` with commit info and prints it to terminal after build
- No runtime changes — build info is only in the output file and terminal

## Test plan
- [ ] Run `npm run build` and verify git info is printed at the end
- [ ] Check `build/build-info.txt` contains correct commit hash, message, dirty status, and timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)