### PR TITLE
feat: add JSON import for snoozed tabs

### DIFF
--- a/src/components/OptionsPage/SleepingTabsPage.tsx
+++ b/src/components/OptionsPage/SleepingTabsPage.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState, Fragment, useCallback } from 'react';
+import React, { useEffect, useState, Fragment, useCallback, useRef } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { styled as muiStyled } from '@mui/material/styles';
 import styled from 'styled-components';
 import { openTabs } from '../../core/wakeup';
 import { getSnoozedTabs } from '../../core/storage';
-import { MSG_DELETE_SNOOZED_TABS } from '../../core/messages';
+import { MSG_DELETE_SNOOZED_TABS, MSG_IMPORT_SNOOZED_TABS } from '../../core/messages';
 import { getSleepingTabByWakeupGroups, type TabGroup } from './groupSleepingTabs';
-import type { SnoozedTab } from '@/types';
+import type { SnoozedTab, SnoozePeriod } from '@/types';
+import { SNOOZE_TYPES } from '@/types';
 import { formatWakeupDescription } from './formatWakeupDescription';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -15,6 +16,7 @@ import ListSubheader from '@mui/material/ListSubheader';
 import IconButton from '@mui/material/IconButton';
 import HotelIcon from '@mui/icons-material/Hotel';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import Button from '@mui/material/Button';
 import Zoom from '@mui/material/Zoom';
@@ -53,6 +55,38 @@ const StyledFab = muiStyled(Fab)<{ component?: React.ElementType; to?: string; t
   right: theme.spacing(3),
 }));
 
+const isValidSnoozePeriod = (p: unknown): p is SnoozePeriod => {
+  if (typeof p !== 'object' || p === null) return false;
+  const period = p as Record<string, unknown>;
+  switch (period.type) {
+    case 'daily':
+      return typeof period.hour === 'number';
+    case 'weekly':
+      return typeof period.hour === 'number' && Array.isArray(period.days) && period.days.every((d: unknown) => typeof d === 'number');
+    case 'monthly':
+      return typeof period.hour === 'number' && typeof period.day === 'number';
+    case 'yearly':
+      return typeof period.hour === 'number' && Array.isArray(period.date) && period.date.length === 2 && period.date.every((d: unknown) => typeof d === 'number');
+    default:
+      return false;
+  }
+};
+
+const isValidSnoozedTab = (tab: unknown): tab is SnoozedTab => {
+  if (typeof tab !== 'object' || tab === null) return false;
+  const t = tab as Record<string, unknown>;
+  if (
+    typeof t.url !== 'string' ||
+    typeof t.title !== 'string' ||
+    typeof t.favicon !== 'string' ||
+    typeof t.when !== 'number' ||
+    typeof t.sleepStart !== 'number' ||
+    !(SNOOZE_TYPES as readonly string[]).includes(t.type as string)
+  ) return false;
+  if (t.period !== undefined && !isValidSnoozePeriod(t.period)) return false;
+  return true;
+};
+
 const exportSnoozedTabs = async () => {
   const tabs = await getSnoozedTabs();
   const json = JSON.stringify(tabs, null, 2);
@@ -69,7 +103,40 @@ const exportSnoozedTabs = async () => {
 const SleepingTabsPage = (): React.ReactNode => {
   const [ visibleTabGroupsState, setVisibleTabGroupsState ] = useState<Array<TabGroup>>([]);
   const [ hidePeriodicState, setHidePeriodicState ] = useState(false);
-  
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const importSnoozedTabs = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    event.target.value = ''; // reset so the same file can be re-selected
+    try {
+      const parsed: unknown = JSON.parse(await file.text());
+      if (!Array.isArray(parsed)) {
+        alert('Invalid backup file: expected a JSON array.');
+        return;
+      }
+      const validTabs = parsed.filter(isValidSnoozedTab);
+      const skipped = parsed.length - validTabs.length;
+      if (validTabs.length === 0) {
+        alert('No valid snoozed tabs found in the file.');
+        return;
+      }
+      const response = await chrome.runtime.sendMessage({ action: MSG_IMPORT_SNOOZED_TABS, tabs: validTabs });
+      if (!response?.success) {
+        alert('Import failed. Please try again.');
+        return;
+      }
+      const added: number = response.added ?? 0;
+      const duped = validTabs.length - added;
+      const parts: string[] = [`Imported ${added} tab(s).`];
+      if (duped > 0) parts.push(`${duped} duplicate${duped === 1 ? '' : 's'} skipped.`);
+      if (skipped > 0) parts.push(`${skipped} entr${skipped === 1 ? 'y' : 'ies'} skipped due to invalid format.`);
+      alert(parts.join(' '));
+    } catch {
+      alert('Failed to parse the backup file. Please select a valid JSON file.');
+    }
+  };
+
   const refreshSnoozedTabs = useCallback(async () => {
     const groups: Array<TabGroup> = await getSleepingTabByWakeupGroups(hidePeriodicState);
     setVisibleTabGroupsState(groups);
@@ -179,14 +246,31 @@ const SleepingTabsPage = (): React.ReactNode => {
         <SectionTitle>
           {visibleTabGroupsState.flatMap(g => g.tabs).length || '0'} Sleeping Tabs
         </SectionTitle>
-        <Button
-          variant="outlined"
-          startIcon={<FileDownloadIcon />}
-          onClick={exportSnoozedTabs}
-          sx={{ color: 'primary.main', borderColor: 'primary.main' }}
-        >
-          Export
-        </Button>
+        <ButtonGroup>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json"
+            onChange={importSnoozedTabs}
+            style={{ display: 'none' }}
+          />
+          <Button
+            variant="outlined"
+            startIcon={<FileUploadIcon />}
+            onClick={() => fileInputRef.current?.click()}
+            sx={{ color: 'primary.main', borderColor: 'primary.main' }}
+          >
+            Import
+          </Button>
+          <Button
+            variant="outlined"
+            startIcon={<FileDownloadIcon />}
+            onClick={exportSnoozedTabs}
+            sx={{ color: 'primary.main', borderColor: 'primary.main' }}
+          >
+            Export
+          </Button>
+        </ButtonGroup>
       </SectionHeader>
       {visibleTabGroupsState.length > 0 ? (
         <StyledList>
@@ -236,6 +320,11 @@ const SectionHeader = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 16px 24px 0;
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: 8px;
 `;
 
 const SectionTitle = styled.h2`

--- a/src/core/backgroundMain.ts
+++ b/src/core/backgroundMain.ts
@@ -147,8 +147,8 @@ export function runBackgroundScript() {
       const { tabs } = message;
       console.log(`📨 [SW] Received importSnoozedTabs message for ${tabs?.length} tab(s)`);
       addSnoozedTabs(tabs)
-        .then(() => scheduleWakeupAlarm('auto'))
-        .then(() => sendResponse({ success: true }))
+        .then(({ added }) => scheduleWakeupAlarm('auto').then(() => added))
+        .then(added => sendResponse({ success: true, added }))
         .catch(error => {
           console.error('importSnoozedTabs message handler failed:', error);
           sendResponse({ success: false, error: error.message });

--- a/src/core/backgroundMain.ts
+++ b/src/core/backgroundMain.ts
@@ -4,7 +4,7 @@
  * without a view.
  */
 import { repeatLastSnooze, snoozeTabs } from './snooze';
-import { MSG_SNOOZE_TABS, MSG_DELETE_SNOOZED_TABS } from './messages';
+import { MSG_SNOOZE_TABS, MSG_DELETE_SNOOZED_TABS, MSG_IMPORT_SNOOZED_TABS } from './messages';
 import {
   registerEventListeners as registerWakeupEventListeners,
   scheduleWakeupAlarm,
@@ -32,7 +32,7 @@ import {
   registerEventListeners as registerBadgeEventListeners,
 } from './badge';
 import { getSettings, saveSettings } from './settings';
-import { saveRecentlyWokenTabs } from './storage';
+import { addSnoozedTabs, saveRecentlyWokenTabs } from './storage';
 
 // Clear recently woken tabs on every Service Worker startup.
 // This clears stale processing state from previous SW instances,
@@ -138,6 +138,19 @@ export function runBackgroundScript() {
         .then(() => sendResponse({ success: true }))
         .catch(error => {
           console.error('deleteSnoozedTabs message handler failed:', error);
+          sendResponse({ success: false, error: error.message });
+        });
+      return true; // keep channel open for async sendResponse
+    }
+
+    if (message.action === MSG_IMPORT_SNOOZED_TABS) {
+      const { tabs } = message;
+      console.log(`📨 [SW] Received importSnoozedTabs message for ${tabs?.length} tab(s)`);
+      addSnoozedTabs(tabs)
+        .then(() => scheduleWakeupAlarm('auto'))
+        .then(() => sendResponse({ success: true }))
+        .catch(error => {
+          console.error('importSnoozedTabs message handler failed:', error);
           sendResponse({ success: false, error: error.message });
         });
       return true; // keep channel open for async sendResponse

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -2,4 +2,5 @@
 // Used by popup/options → service worker, and SW → offscreen document.
 export const MSG_SNOOZE_TABS = 'snoozeTabs';
 export const MSG_DELETE_SNOOZED_TABS = 'deleteSnoozedTabs';
+export const MSG_IMPORT_SNOOZED_TABS = 'importSnoozedTabs';
 export const MSG_PLAY_AUDIO = 'playAudio';

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -42,7 +42,7 @@ export async function getSnoozedTabs(): Promise<SnoozedTab[]> {
 
 export function addSnoozedTabs(
   tabsToAdd: SnoozedTab[]
-): Promise<void> {
+): Promise<{ added: number }> {
   return withStorageLock(async () => {
     const tabs = await getSnoozedTabs();
     const newTabs = tabsToAdd.filter(toAdd => !includesTab(tabs, toAdd));
@@ -52,6 +52,7 @@ export function addSnoozedTabs(
     } else if (tabsToAdd.length > 0) {
       console.log(`⏭️ All ${tabsToAdd.length} tab(s) already in storage, skipping add`);
     }
+    return { added: newTabs.length };
   });
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,16 +28,19 @@ export type SnoozePeriod =
   | { type: 'monthly'; hour: number; day: number }
   | { type: 'yearly'; hour: number; date: [number, number] };
 
-export type SnoozeType =
-  | 'later'
-  | 'evening'
-  | 'tomorrow'
-  | 'weekend'
-  | 'next_week'
-  | 'in_a_month'
-  | 'someday'
-  | 'periodically'
-  | 'specific_date';
+export const SNOOZE_TYPES = [
+  'later',
+  'evening',
+  'tomorrow',
+  'weekend',
+  'next_week',
+  'in_a_month',
+  'someday',
+  'periodically',
+  'specific_date',
+] as const;
+
+export type SnoozeType = typeof SNOOZE_TYPES[number];
 
 export interface SnoozedTab {
   title: string;


### PR DESCRIPTION
## Summary
- Add `MSG_IMPORT_SNOOZED_TABS` message and service worker handler that imports tabs via `addSnoozedTabs()` (with dedup) and reschedules the wakeup alarm
- Add Import button next to Export on the Sleeping Tabs dashboard with file picker, JSON parsing, and validation
- Derive `SnoozeType` from `SNOOZE_TYPES as const` array so the type and runtime validator share a single source of truth
- Validate imported tabs against `SNOOZE_TYPES` (rejects unknown type values) and validate `SnoozePeriod` structure for all 4 variants (`daily`, `weekly`, `monthly`, `yearly`)
- Check `sendMessage` response and surface errors to the user if the service worker handler fails
- Show import result summary with duplicate and invalid-format counts (e.g. "Imported 6 tab(s). 2 duplicates skipped. 1 entry skipped due to invalid format.")

Closes #84

## Test plan
- [x] Export snoozed tabs as JSON backup
- [x] Delete some tabs, then import the backup file
- [x] Verify tabs are restored and duplicates are not created
- [x] Verify wakeup alarms are rescheduled after import
- [x] Try importing an invalid file and verify error alert appears
- [x] Try importing a file with some invalid entries and verify the partial-skip warning appears
- [x] Manually corrupt a tab's `type` field to an invalid value and verify it is skipped
- [x] Import a backup that overlaps with existing tabs and verify the duplicate count is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)