### PR TITLE
fix(dev): resolve offscreen module import error during dev server

### DIFF
--- a/offscreen.html
+++ b/offscreen.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script type="module" src="./assets/offscreen.js"></script>
+  <script type="module" src="./src/core/offscreen.ts"></script>
 </head>
 <body>
   <!-- This page runs in the background and has DOM access -->

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,16 +63,7 @@ export default defineConfig({
     minify: false, // Keep unminified for Chrome Web Store review
     rollupOptions: {
       input: {
-        offscreen: resolve(__dirname, 'src/core/offscreen.ts'),
-      },
-      output: {
-        entryFileNames: (chunkInfo) => {
-          // Place offscreen script in assets directory
-          if (chunkInfo.name === 'offscreen') {
-            return 'assets/offscreen.js';
-          }
-          return 'assets/[name]-[hash].js';
-        },
+        offscreen: resolve(__dirname, 'offscreen.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary
- `offscreen.html` referenced `./assets/offscreen.js` (a build output path), which CRXJS's internal rollup couldn't resolve during dev
- Changed to reference `./src/core/offscreen.ts` directly so Vite handles `.ts` module resolution
- Simplified rollup config to use `offscreen.html` as the entry instead of the `.ts` source with custom output paths

Closes the `Could not resolve './messages' from src/core/offscreen.ts` error when running `npm run start`.

## Test plan
- [x] `npm run start` starts without errors
- [x] `npm run build` produces correct output with `offscreen.html` and `offscreen-*.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)