### PR TITLE
fix(snooze): correct 'Next Weekend' calculation on Sundays

### DIFF
--- a/src/components/SnoozePanel/calcSnoozeOptions.test.ts
+++ b/src/components/SnoozePanel/calcSnoozeOptions.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import moment from 'moment';
+import calcSnoozeOptions from './calcSnoozeOptions';
+import type { Settings } from '@/types';
+
+// Explicit settings — tests should not rely on DEFAULT_SETTINGS so that
+// changes to defaults don't silently affect these assertions.
+const TEST_SETTINGS: Settings = {
+  weekEndDay: 6,      // Saturday
+  weekStartDay: 1,    // Monday
+  workdayStart: 8,
+  workdayEnd: 19,
+  laterTodayHoursDelta: 3,
+  somedayMonthsDelta: 3,
+  badge: 'hidden',
+  playSoundEffects: true,
+  playNotificationSound: true,
+  showNotifications: true,
+  version: 3,
+  totalSnoozeCount: 0,
+  installDate: 0,
+  weeklyUsage: { weekNumber: 0, usageCount: 0 },
+  showSupportReminders: true,
+  lastSupportReminderDate: 0,
+};
+
+// Pinned reference week: Mon 2026-03-30 → Sun 2026-04-05
+// This weekend (Saturday):      2026-04-04
+// Next weekend (Saturday after): 2026-04-11
+const THIS_SATURDAY = '2026-04-04';
+const NEXT_SATURDAY = '2026-04-11';
+
+function getWeekendOption() {
+  const options = calcSnoozeOptions(TEST_SETTINGS);
+  const opt = options.find(o => o.id === 'weekend');
+  if (!opt?.when) throw new Error('weekend option not found');
+  return opt;
+}
+
+describe('calcSnoozeOptions — weekend option', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['Monday',    '2026-03-30T10:00:00'],
+    ['Tuesday',   '2026-03-31T10:00:00'],
+    ['Wednesday', '2026-04-01T10:00:00'],
+    ['Thursday',  '2026-04-02T10:00:00'],
+    ['Friday',    '2026-04-03T10:00:00'],
+  ])('on %s shows "This Weekend" targeting %s', (_, dateTime) => {
+    vi.setSystemTime(new Date(dateTime));
+    const opt = getWeekendOption();
+    expect(opt.title).toBe('This Weekend');
+    expect(moment(opt.when).format('YYYY-MM-DD')).toBe(THIS_SATURDAY);
+  });
+
+  it.each([
+    ['Saturday', '2026-04-04T10:00:00'],
+    ['Sunday',   '2026-04-05T10:00:00'],
+  ])('on %s shows "Next Weekend" targeting the following Saturday', (_, dateTime) => {
+    vi.setSystemTime(new Date(dateTime));
+    const opt = getWeekendOption();
+    expect(opt.title).toBe('Next Weekend');
+    expect(moment(opt.when).format('YYYY-MM-DD')).toBe(NEXT_SATURDAY);
+  });
+});

--- a/src/components/SnoozePanel/calcSnoozeOptions.ts
+++ b/src/components/SnoozePanel/calcSnoozeOptions.ts
@@ -74,7 +74,11 @@ export default function calcSnoozeOptions(
     ? dayStart(moment()) // if its very late, tomorrow = today.
     : dayStart(moment().add(1, 'days'));
   const weekendTime = isWeekend
-    ? dayStart(moment().day(7 + weekEndDay)) // choose next weekend
+    ? dayStart(
+        moment().day() < weekEndDay
+          ? moment().day(weekEndDay) // Sunday → this Saturday (6 days away)
+          : moment().day(7 + weekEndDay) // Saturday → next Saturday (7 days away)
+      )
     : dayStart(moment().day(weekEndDay));
   const nextWeekTime = dayStart(moment().day(weekStartDay + 7)); // next day which start the week
   const inAMonthTime = dayStart(moment().add(1, 'months'));

--- a/src/components/SnoozePanel/calcSnoozeOptions.ts
+++ b/src/components/SnoozePanel/calcSnoozeOptions.ts
@@ -73,12 +73,9 @@ export default function calcSnoozeOptions(
   const tomorrowTime = isVeryLateAtNight
     ? dayStart(moment()) // if its very late, tomorrow = today.
     : dayStart(moment().add(1, 'days'));
+  const nextWeekendDay = moment().day() === weekEndDay ? 7 + weekEndDay : weekEndDay;
   const weekendTime = isWeekend
-    ? dayStart(
-        moment().day() < weekEndDay
-          ? moment().day(weekEndDay) // Sunday → this Saturday (6 days away)
-          : moment().day(7 + weekEndDay) // Saturday → next Saturday (7 days away)
-      )
+    ? dayStart(moment().day(nextWeekendDay))
     : dayStart(moment().day(weekEndDay));
   const nextWeekTime = dayStart(moment().day(weekStartDay + 7)); // next day which start the week
   const inAMonthTime = dayStart(moment().add(1, 'months'));

--- a/src/components/SnoozePanel/calcSnoozeOptions.ts
+++ b/src/components/SnoozePanel/calcSnoozeOptions.ts
@@ -49,6 +49,7 @@ export default function calcSnoozeOptions(
   const isVeryLateAtNight = moment().hour() <= 3;
   const isNightTime =
     moment().hour() >= workdayEnd || moment().hour() < 3;
+  // isWeekend covers both days: the first day (e.g. Saturday) and the second (e.g. Sunday)
   const isWeekend =
     moment().day() === weekEndDay ||
     moment().day() === (weekEndDay + 1) % 7;
@@ -73,10 +74,11 @@ export default function calcSnoozeOptions(
   const tomorrowTime = isVeryLateAtNight
     ? dayStart(moment()) // if its very late, tomorrow = today.
     : dayStart(moment().add(1, 'days'));
-  const nextWeekendDay = moment().day() === weekEndDay ? 7 + weekEndDay : weekEndDay;
-  const weekendTime = isWeekend
-    ? dayStart(moment().day(nextWeekendDay))
-    : dayStart(moment().day(weekEndDay));
+  // Use >= so that any day at or past weekEndDay (e.g. Saturday when weekend starts Friday)
+  // correctly targets next weekend rather than going backwards within the current week.
+  const weekendTime = moment().day() >= weekEndDay
+    ? dayStart(moment().day(weekEndDay + 7)) // at or past weekend start → next weekend
+    : dayStart(moment().day(weekEndDay));     // before weekend start → this upcoming weekend
   const nextWeekTime = dayStart(moment().day(weekStartDay + 7)); // next day which start the week
   const inAMonthTime = dayStart(moment().add(1, 'months'));
   const somedayTime = dayStart(


### PR DESCRIPTION
## Summary
- On Sundays, \"Next Weekend\" pointed 13 days ahead instead of 6
- Simplified the two-variable logic (`nextWeekendDay` + `weekendTime`) into a single conditional on `weekendTime`
- Changed `=== weekEndDay` to `>= weekEndDay` so mid-weekend days (e.g. Saturday when weekend starts Friday) also correctly point to the next weekend rather than going backwards

Closes #71

## Test plan
- [ ] On a Sunday, verify \"Next Weekend\" shows the upcoming Saturday (6 days away)
- [ ] On a Saturday, verify \"Next Weekend\" shows the following Saturday (7 days away)
- [ ] On a weekday, verify \"This Weekend\" shows the correct upcoming Saturday

🤖 Generated with [Claude Code](https://claude.com/claude-code)