### PR TITLE
fix(dev): output dev server to dev-build/ to preserve production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Build outputs
 /build
+/dev-build
 /dist
 *.zip
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,103 +14,107 @@ const gitHash = execSync('git rev-parse --short HEAD').toString().trim()
 const gitCommitMsg = execSync('git log -1 --pretty=%s').toString().trim()
 const gitDirty = execSync('git status --porcelain').toString().trim() !== ''
 
-export default defineConfig({
-  plugins: [
-    react(),
-    crx({ manifest }),
-    tsconfigPaths(),
-    {
-      name: 'build-info',
-      closeBundle() {
-        const info = [
-          `Commit: ${gitHash}`,
-          `Message: ${gitCommitMsg}`,
-          `Dirty: ${gitDirty ? 'yes' : 'no'}`,
-          `Built: ${new Date().toISOString()}`,
-        ].join('\n')
-        writeFileSync('build/build-info.txt', info + '\n')
-        console.log('\n📦 Build Info:\n' + info + '\n')
+export default defineConfig(({ command }) => {
+  const outDir = command === 'serve' ? 'dev-build' : 'build'
+
+  return {
+    plugins: [
+      react(),
+      crx({ manifest }),
+      tsconfigPaths(),
+      {
+        name: 'build-info',
+        closeBundle() {
+          const info = [
+            `Commit: ${gitHash}`,
+            `Message: ${gitCommitMsg}`,
+            `Dirty: ${gitDirty ? 'yes' : 'no'}`,
+            `Built: ${new Date().toISOString()}`,
+          ].join('\n')
+          writeFileSync(`${outDir}/build-info.txt`, info + '\n')
+          console.log('\n📦 Build Info:\n' + info + '\n')
+        }
       }
-    }
-  ],
-
-  esbuild: {
-    target: 'chrome109',
-    jsx: 'automatic',
-  },
-
-  optimizeDeps: {
-    include: [
-      "@mui/material/styles",
-      "@mui/material",
-      "@emotion/react",
-      "@emotion/styled",
-      "react",
-      "react-dom"
     ],
-    esbuildOptions: {
-      loader: {
-        '.js': 'jsx',
+
+    esbuild: {
+      target: 'chrome109',
+      jsx: 'automatic',
+    },
+
+    optimizeDeps: {
+      include: [
+        "@mui/material/styles",
+        "@mui/material",
+        "@emotion/react",
+        "@emotion/styled",
+        "react",
+        "react-dom"
+      ],
+      esbuildOptions: {
+        loader: {
+          '.js': 'jsx',
+        },
+      }
+    },
+
+    build: {
+      target: 'chrome109',
+      // @crxjs/vite-plugin handles the build configuration
+      outDir,
+      emptyOutDir: true,
+      minify: false, // Keep unminified for Chrome Web Store review
+      rollupOptions: {
+        input: {
+          offscreen: resolve(__dirname, 'offscreen.html'),
+        },
       },
-    }
-  },
+    },
 
-  build: {
-    target: 'chrome109',
-    // @crxjs/vite-plugin handles the build configuration
-    outDir: 'build',
-    emptyOutDir: true,
-    minify: false, // Keep unminified for Chrome Web Store review
-    rollupOptions: {
-      input: {
-        offscreen: resolve(__dirname, 'offscreen.html'),
+    // Define globals for background scripts
+    define: {
+      'global': 'globalThis',
+      'process.env.NODE_ENV': '"production"',
+    },
+
+    // Configure for Chrome extension development
+    server: {
+      port: 3000,
+      strictPort: true,
+      fs: {
+        allow: ['..'],
       },
     },
-  },
-
-  // Define globals for background scripts
-  define: {
-    'global': 'globalThis',
-    'process.env.NODE_ENV': '"production"',
-  },
-
-  // Configure for Chrome extension development
-  server: {
-    port: 3000,
-    strictPort: true,
-    fs: {
-      allow: ['..'],
+    // Resolve configuration
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, 'src'),
+      },
     },
-  },
-  // Resolve configuration
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, 'src'),
-    },
-  },
 
-  // Test configuration
-  test: {
-    environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setupTests.ts'],
-    globals: true,
-    // Mock Chrome APIs for testing
-    deps: {
-      inline: ['@testing-library/jest-dom']
-    },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'html', 'json'],
-      exclude: [
-        'node_modules/**',
-        'src/__tests__/**',
-        '**/*.test.ts',
-        '**/*.test.tsx',
-        'vite.config.ts',
-        'public/**',
-        'build/**',
-        'src/setupChromeMock.ts'
-      ]
+    // Test configuration
+    test: {
+      environment: 'jsdom',
+      setupFiles: ['./src/__tests__/setupTests.ts'],
+      globals: true,
+      // Mock Chrome APIs for testing
+      deps: {
+        inline: ['@testing-library/jest-dom']
+      },
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'html', 'json'],
+        exclude: [
+          'node_modules/**',
+          'src/__tests__/**',
+          '**/*.test.ts',
+          '**/*.test.tsx',
+          'vite.config.ts',
+          'public/**',
+          'build/**',
+          'src/setupChromeMock.ts'
+        ]
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary
- Dev server (`npm run start` / `npm run dev`) was writing to `build/`, overwriting the production extension and breaking it when the server stopped
- Switched `defineConfig` to function form to access `command` (`serve` vs `build`)
- Dev server now outputs to `dev-build/`, production build continues to use `build/`
- Added `/dev-build` to `.gitignore`

Closes #87

## Test plan
- [ ] `npm run start` populates `dev-build/` — load that as unpacked extension for dev
- [ ] `npm run build` still outputs to `build/` — production build unaffected
- [ ] `build/` is not modified when running the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)