### PR TITLE
fix(deps): update flatted to 3.4.2 (CVE-2026-33228)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary
- Updates `flatted` from 3.3.3 → 3.4.2 (transitive dev dependency via `eslint → file-entry-cache → flat-cache`)
- Resolves Dependabot alert #1 / CVE-2026-33228 (prototype pollution via `flatted.parse()`)
- No production impact — `flatted` is not bundled into the extension

## Test plan
- [ ] Confirm `npm ls flatted` shows 3.4.2
- [ ] Confirm `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)