### PR TITLE
fix(commands): play snooze sound when repeating last snooze via keyboard shortcut

### DIFF
--- a/src/core/backgroundMain.ts
+++ b/src/core/backgroundMain.ts
@@ -4,7 +4,8 @@
  * without a view.
  */
 import { repeatLastSnooze, snoozeTabs } from './snooze';
-import { MSG_SNOOZE_TABS, MSG_DELETE_SNOOZED_TABS, MSG_IMPORT_SNOOZED_TABS } from './messages';
+import { MSG_SNOOZE_TABS, MSG_DELETE_SNOOZED_TABS, MSG_IMPORT_SNOOZED_TABS, MSG_PLAY_AUDIO } from './messages';
+import { SOUND_SNOOZE } from './audio';
 import {
   registerEventListeners as registerWakeupEventListeners,
   scheduleWakeupAlarm,
@@ -99,14 +100,21 @@ export function runBackgroundScript() {
     }
   });
 
-  chrome.commands.onCommand.addListener(command => {
+  chrome.commands.onCommand.addListener(async command => {
     // create a new todo window!, and focus on it
     if (command === COMMAND_NEW_TODO) {
       createTab(TODO_PATH);
     }
 
     if (command === COMMAND_REPEAT_LAST_SNOOZE) {
-      repeatLastSnooze();
+      const snoozed = await repeatLastSnooze();
+      if (snoozed) {
+        const settings = await getSettings();
+        if (settings.playSoundEffects) {
+          await ensureOffscreenDocument();
+          chrome.runtime.sendMessage({ action: MSG_PLAY_AUDIO, sound: SOUND_SNOOZE });
+        }
+      }
     }
 
     if (command === COMMAND_OPEN_SLEEPING_TABS) {

--- a/src/core/snooze.ts
+++ b/src/core/snooze.ts
@@ -79,7 +79,7 @@ export async function snoozeActiveTab(config: SnoozeConfig) {
   return snoozeTab(activeTab, config);
 }
 
-export async function repeatLastSnooze() {
+export async function repeatLastSnooze(): Promise<boolean> {
   const snoozedTabs = await getSnoozedTabs();
   const lastSnooze = getRecentlySnoozedTab(snoozedTabs);
 
@@ -89,16 +89,17 @@ export async function repeatLastSnooze() {
     !lastSnooze ||
     Date.now() - lastSnooze.sleepStart > 1000 * 60 * 10
   ) {
-    return;
+    return false;
   }
 
   // track(EVENTS.REPEAT_SNOOZE);
 
-  return snoozeActiveTab({
+  await snoozeActiveTab({
     wakeupTime: lastSnooze.period ? undefined : lastSnooze.when,
     period: lastSnooze.period,
     type: lastSnooze.type,
   });
+  return true;
 }
 
 export async function resnoozePeriodicTab(snoozedTab: SnoozedTab) {


### PR DESCRIPTION
## Summary
- `repeatLastSnooze` now returns `Promise<boolean>` — `true` if a snooze was performed, `false` if it bailed early (no recent snooze)
- The `COMMAND_REPEAT_LAST_SNOOZE` handler in `backgroundMain.ts` now plays `SOUND_SNOOZE` via the offscreen document when the snooze succeeds, respecting the `playSoundEffects` setting

## Test plan
- [ ] Trigger repeat last snooze via keyboard shortcut (`Alt+Shift+S`) shortly after snoozing a tab — confirm snooze sound plays
- [ ] Trigger with `playSoundEffects` disabled in settings — confirm no sound
- [ ] Trigger with no recent snooze (or >10 min ago) — confirm no sound and no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)